### PR TITLE
Allocate struct fields in place

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Release/*
 *.sln 
 *.tlog 
 build 
+bin 

--- a/examples/server/pages/test.txt
+++ b/examples/server/pages/test.txt
@@ -1,1 +1,1 @@
-What's up my name is Jeff, I'm 19 and I never learned how to read, yet
+What's up my name is Jeff, I'm 19 and I never learned how to read

--- a/examples/server/src/lib.c
+++ b/examples/server/src/lib.c
@@ -187,6 +187,8 @@ static TINY_FOREIGN_FUNCTION(ListDir)
         ArrayPush(a, &val);
     } while(FindNextFile(hFind, &data));
 
+	FindClose(hFind);
+
     return Tiny_NewNative(thread, a, &ArrayProp);
 #else
     return Tiny_Null;

--- a/include/tiny_detail.h
+++ b/include/tiny_detail.h
@@ -28,7 +28,7 @@ typedef struct Tiny_Object
         struct
         {
             Word n;
-            Tiny_Value* fields;
+            Tiny_Value fields[];
         } ostruct;
 	};
 } Tiny_Object;


### PR DESCRIPTION
Instead of allocating struct fields separately, just put them all at the end of the Tiny_Object allocation; reduces cache misses and eliminates the need to free structs specially.