### PR TITLE
Safe any

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 * Make sure VM bytecode instructions and data are aligned properly (DONE)
 
 * First class types (store a "type" which is just an integer in the VM)
-* Safer "any" type: must be explicitly converted
+* Safer "any" type: must be explicitly converted (DONE)
 
 * Once "any" is safe, we can have typed bytecode instructions; `OP_ADD_INT`, `OP_EQUAL_STRING` etc
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,5 @@
-* Make sure VM bytecode instructions and data are aligned properly
+* Make sure VM bytecode instructions and data are aligned properly (DONE)
+
 * First class types (store a "type" which is just an integer in the VM)
 * Safer "any" type: must be explicitly converted
 
@@ -60,5 +61,13 @@ e.get(ItemComponent)
 
 Of course, if it's implemented at the tiny level, then generics must also be implemented at the C level:
 ```c
-Tiny_BindFunction(state, "get(entity, $t): t", Lib_GetComponent);
+// $$t means pass in the actual type value as well (so we can inspect it in the C code to get the appropriate component for example)
+Tiny_BindFunction(state, "get(entity, $$t): t", Lib_GetComponent);
+```
+
+```
+Tiny_RegisterType(state, "array($t)");
+
+// $t is matched with the t of the array passed in
+Tiny_BindFunction(state, "get(array($t), int): t");
 ```

--- a/examples/notepad/scripts/main.tiny
+++ b/examples/notepad/scripts/main.tiny
@@ -25,7 +25,7 @@ func pop_hop(): void {
         return;
     }
     
-    y := array_pop(hop_buffer)
+    y := cast(array_pop(hop_buffer), int)
     
     if array_len(unhop_buffer) >= max_hop_buffer_len {
         array_shift(unhop_buffer)
@@ -41,7 +41,7 @@ func pop_unhop(): void {
         return;
     }
     
-    y := array_pop(unhop_buffer) 
+    y := cast(array_pop(unhop_buffer), int)
      
     push_hop()
     

--- a/examples/notepad/src/editor.c
+++ b/examples/notepad/src/editor.c
@@ -725,7 +725,7 @@ static void BindFunctions(Tiny_State* state)
 
     Tiny_BindFunction(state, "line_count(): int", Lib_LineCount);
     Tiny_BindFunction(state, "get_line(...): str", Lib_GetLine);
-    Tiny_BindFunction(state, "get_line_from", Lib_GetLineFrom);
+    Tiny_BindFunction(state, "get_line_from(...): str", Lib_GetLineFrom);
     Tiny_BindFunction(state, "set_line(...): void", Lib_SetLine);
     Tiny_BindFunction(state, "remove_line(...): void", Lib_RemoveLine);
     Tiny_BindFunction(state, "insert_empty_line(...): void", Lib_InsertEmptyLine);

--- a/examples/server/scripts/index.tiny
+++ b/examples/server/scripts/index.tiny
@@ -9,7 +9,7 @@ func view() {
     titles := array()
 
     for i := 0; i < array_len(files); i += 1 {
-        s := array_get(files, i)
+        s := cast(array_get(files, i), str)
         k := strchr(s, '.')
 
         array_push(titles, substr(s, 0, k))

--- a/include/tiny_tokens.h
+++ b/include/tiny_tokens.h
@@ -60,6 +60,7 @@ typedef enum
     TINY_TOK_FOREIGN,
     TINY_TOK_STRUCT,
     TINY_TOK_NEW,
+    TINY_TOK_CAST,
 
     TINY_TOK_EOF,
 } Tiny_TokenKind;

--- a/src/tiny_lexer.c
+++ b/src/tiny_lexer.c
@@ -162,6 +162,7 @@ Tiny_TokenKind Tiny_GetToken(Tiny_Lexer* l)
         if(strcmp(l->lexeme, "else") == 0) return TINY_TOK_ELSE;
         if(strcmp(l->lexeme, "struct") == 0) return TINY_TOK_STRUCT;
 		if(strcmp(l->lexeme, "new") == 0) return TINY_TOK_NEW;
+        if(strcmp(l->lexeme, "cast") == 0) return TINY_TOK_CAST;
 
         return TINY_TOK_IDENT;
     }

--- a/test/src/test.c
+++ b/test/src/test.c
@@ -520,10 +520,10 @@ static void test_RevPolishCalc(void)
 		"op := \"\"\n"
 		"while op != \"quit\" {\n"
 		"op = my_input()\n"
-		"if stridx(op, 0) == '+' array_push(stack, array_pop(stack) + array_pop(stack))\n"
-		"else if stridx(op, 0) == '-' array_push(stack, array_pop(stack) - array_pop(stack))\n"
-		"else if stridx(op, 0) == '*' array_push(stack, array_pop(stack) * array_pop(stack))\n"
-		"else if stridx(op, 0) == '/' array_push(stack, array_pop(stack) / array_pop(stack))\n"
+		"if stridx(op, 0) == '+' array_push(stack, cast(array_pop(stack), float) + cast(array_pop(stack), float))\n"
+		"else if stridx(op, 0) == '-' array_push(stack, cast(array_pop(stack), float) - cast(array_pop(stack), float))\n"
+		"else if stridx(op, 0) == '*' array_push(stack, cast(array_pop(stack), float) * cast(array_pop(stack), float))\n"
+		"else if stridx(op, 0) == '/' array_push(stack, cast(array_pop(stack), float) / cast(array_pop(stack), float))\n"
 		"else if op != \"quit\" array_push(stack, ston(op)) }\n";
 
 	Tiny_CompileString(state, "test_rpn", code);


### PR DESCRIPTION
Automatically convert _to_ any, but not back; requires explicit cast. Currently a no-op, but in the future casting could actually convert between types.

It also doesn't check for convertibility, but this will need to be done in the future once we have interfaces.